### PR TITLE
Fix customer dob

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -134,8 +134,10 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper {
 		
 		$email = $order->getCustomerEmail();
 		
-		$dob = $order->getCustomerDob() ?: '1985-10-10';
-
+		$dob = $order->getCustomerDob()
+            		? date('Y-m-d', strtotime($order->getCustomerDob()))
+            		: '1985-10-10';
+		
 		$ddd_telephone 		= $this->getNumberOrDDD($order->getBillingAddress()->getTelephone(), true);
 		$number_telephone 	= $this->getNumberOrDDD($order->getBillingAddress()->getTelephone(), false);
 


### PR DESCRIPTION
Quando o cliente já está cadastrado, ele vem com a data de nascimento contendo data e hora, isso acaba dando erro na hora de enviar para o Moip.