### PR TITLE
Desabilitado para uso interno

### DIFF
--- a/Model/PaymentMethodBoleto.php
+++ b/Model/PaymentMethodBoleto.php
@@ -29,6 +29,7 @@ class PaymentMethodBoleto extends \Magento\Payment\Model\Method\Cc
 	protected $_cart;
 	protected $_moipHelper;
 	protected $_infoBlockType = 'Moip\Magento2\Block\Info\Boleto';
+	protected $_canUseInternal          = false;
 
     public function __construct(
         \Magento\Framework\Model\Context $context,

--- a/Model/PaymentMethodCc.php
+++ b/Model/PaymentMethodCc.php
@@ -30,6 +30,7 @@ class PaymentMethodCc extends \Magento\Payment\Model\Method\Cc
     protected $_debugReplacePrivateDataKeys = ['number', 'exp_month', 'exp_year', 'cvc'];
 	protected $_cart;
 	protected $_moipHelper;
+	protected $_canUseInternal          = false;
 	
     public function __construct(
         \Magento\Framework\Model\Context $context,


### PR DESCRIPTION
Devido ao módulo não ter suporte ao uso interno de pagamento. Causava conflito ao criar ordem pelo painel do admin.
"Element with ID 'moipcc' already exists."
Detalhes do parâmetro "can_use_internal" em: https://devdocs.magento.com/guides/v2.3/payments-integrations/base-integration/payment-option-config.html