### PR TITLE
Fix message exception error

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -1,7 +1,6 @@
 <?php 
 namespace Moip\Magento2\Helper;
-use Magento\Framework\App\Filesystem\DirectoryList;
-use Magento\Backend\App\Action;
+use Magento\Framework\Exception\LocalizedException;
 use Moip\Moip;
 use Moip\Auth\OAuth;
 


### PR DESCRIPTION
fix #60 

Fix `Documento fiscal inválido, CPF ou CNPJ não preenchido` not being showed on checkout page.